### PR TITLE
Use a patched verson of `rgb-lib`.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 actix-web = "4.2.1"
 clap = { version = "4.0.15", features = ["derive"] }
-rgb-lib = { git = "https://github.com/RGB-Tools/rgb-lib", rev = "5f1f097" }
+rgb-lib = { git = "https://github.com/RGB-Tools/rgb-lib", rev = "5211dd8ec43617c393f94e4df0dcb77cb2c7356b" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 


### PR DESCRIPTION
This will be reverted after a patch was merged to the upstream.

Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>
