### PR TITLE
use rgb-lib with blocking reqwest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 actix-web = "4.2.1"
 clap = { version = "4.0.15", features = ["derive", "env"] }
-rgb-lib = { git = "https://github.com/RGB-Tools/rgb-lib", rev = "b0dc38c8a35c0d970c70722c8975f5a7526ff3fd" }
+rgb-lib = { git = "https://github.com/RGB-Tools/rgb-lib", rev = "d1de142dc40d917c8c4fc60e0b1f30a8847eb111" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 

--- a/src/wallet/address.rs
+++ b/src/wallet/address.rs
@@ -14,7 +14,7 @@ pub struct AddressResult {
 #[get("/wallet/address")]
 pub async fn get(arc: web::Data<Arc<RwLock<WalletState>>>) -> impl Responder {
     if let Ok(wallet_state) = arc.write() {
-        match wallet_state.new_wallet() {
+        match wallet_state.new_wallet().await {
             Some(wallet) => HttpResponse::Ok().json(AddressResult {
                 new_address: _new_address(wallet).await.unwrap(),
             }),

--- a/src/wallet/go_online.rs
+++ b/src/wallet/go_online.rs
@@ -29,7 +29,7 @@ pub async fn put(
         Ok(wallet_state) => wallet_state,
         Err(e) => return HttpResponse::BadRequest().body(e.to_string()),
     };
-    match wallet_state.new_wallet() {
+    match wallet_state.new_wallet().await {
         Some(wallet) => {
             match _go_online(
                 wallet,


### PR DESCRIPTION
closes #42.
refs RGB-Tools/rgb-lib#11.

Monaka added an attribute that skips a lint check by Clippy
to the original patch.

Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>
