### PR TITLE
Bump rgb-lib to 0.1.6.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 actix-web = "4.2.1"
 clap = { version = "4.0.15", features = ["derive", "env"] }
-rgb-lib = { git = "https://github.com/RGB-Tools/rgb-lib", rev = "d1de142dc40d917c8c4fc60e0b1f30a8847eb111" }
+rgb-lib = "0.1.6"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 


### PR DESCRIPTION
Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>
