### PR TITLE
Bump rgb-lib to 0.1.9.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ actix-cors = "0.6.4"
 actix-files = "0.6.2"
 clap = { version = "4.0.15", features = ["derive", "env"] }
 rand = "0.8.5"
-rgb-lib = "=0.1.7"
+rgb-lib = "=0.1.9"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 


### PR DESCRIPTION
Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>
